### PR TITLE
Fix content type problems + Fix issue when feed update timestamp differs from latest feed entry

### DIFF
--- a/lib/concourse/resource/rss/check.rb
+++ b/lib/concourse/resource/rss/check.rb
@@ -37,7 +37,7 @@ module Concourse
         def first
           return [] if @feed.items.empty?
 
-          [{ 'pubDate' => @feed.last_build_date }]
+          [{ 'pubDate' => @feed.latest_entry_date }]
         end
       end
     end

--- a/lib/concourse/resource/rss/feed.rb
+++ b/lib/concourse/resource/rss/feed.rb
@@ -8,7 +8,7 @@ module Concourse
   module Resource
     module RSS
       class Feed
-        attr_reader :title, :items, :last_build_date
+        attr_reader :title, :items, :last_build_date, :latest_entry_date
 
         def initialize(url)
           response = Faraday.get(url)
@@ -53,12 +53,18 @@ module Concourse
           @title = feed.channel.title.chomp
           @last_build_date = feed.channel.lastBuildDate
           @items = feed.items.map { |item| cleanup(item) }
+          unless @items.empty?
+            @latest_entry_date = feed.items[0].pubDate
+          end
         end
 
         def handle_as_atom(feed)
           @title = feed.title.content
           @last_build_date = feed.updated.content
           @items = feed.items # .map { |item| cleanup(item) }
+          unless @items.empty?
+            @latest_entry_date = feed.items[0].updated
+          end
         end
 
         def cleanup(item)

--- a/lib/concourse/resource/rss/feed.rb
+++ b/lib/concourse/resource/rss/feed.rb
@@ -35,6 +35,10 @@ module Concourse
         private
 
         def handle(content_type, feed)
+          # some feeds return Charset as uppercase,
+          # which will lead to the content type not being recognized
+          # this fixes this by ensuring that the check is performed on downcased content_type
+          content_type = content_type.to_s.downcase
           case content_type
           when 'application/rss+xml', 'application/rss+xml; charset=utf-8', nil, ''
             handle_as_rss(feed)

--- a/spec/unit/feed_spec.rb
+++ b/spec/unit/feed_spec.rb
@@ -21,6 +21,10 @@ describe Concourse::Resource::RSS::Feed do
       expect(subject.last_build_date).to eq(Time.parse('Thu, 27 Oct 2016 00:00:00 +0000'))
     end
 
+    it 'has the latest entry date' do
+      expect(subject.latest_entry_date).to eq(Time.parse('Thu, 27 Oct 2016 00:00:00 +0000'))
+    end
+
     it 'has a number of items' do
       expect(subject.items).to_not be_empty
       expect(subject.items).to have(20).items


### PR DESCRIPTION
Description:

The following rss feed did not work for us: https://www.cloudfoundry.org/foundryblog/security-advisory/feed/

It failed with "No handler defined for application/rss+xml; charset=UTF-8". This is fixed in this branch by downcasing the content_type before executing the case statement.

After fixing this, we had another issue as the timestamp of the latest feed entry was not matching the feed update timestamp. I solved this by introducing a new accessor :latest_entry_date in the feed class and using this instead of the :last_build_date in Concourse::Resource::RSS::Check.first .

All specs are running and i also added feed spec for latest_entry_date.

Could you please merge this to include those fixes?

Thanks in advance.

Julian